### PR TITLE
fix: drop Lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,18 @@
 {
     "name": "vanilla-token-auth",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vanilla-token-auth",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "WTFPL",
             "dependencies": {
-                "js-cookie": "^2.2.1",
-                "lodash": "^4.17.21"
+                "js-cookie": "^2.2.1"
             },
             "devDependencies": {
-                "@types/js-cookie": "^3.0.2",
-                "@types/lodash": "^4.14.183",
+                "@types/js-cookie": "^2.2.1",
                 "@types/node": "^18.7.6",
                 "tsup": "^6.2.2",
                 "typescript": "^4.7.4"
@@ -72,15 +70,9 @@
             }
         },
         "node_modules/@types/js-cookie": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
-            "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA==",
-            "dev": true
-        },
-        "node_modules/@types/lodash": {
-            "version": "4.14.183",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.183.tgz",
-            "integrity": "sha512-UXavyuxzXKMqJPEpFPri6Ku5F9af6ZJXUneHhvQJxavrEjuHkFp2YnDWHcxJiG7hk8ZkWqjcyNeW1s/smZv5cw==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+            "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -895,11 +887,6 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -1477,15 +1464,9 @@
             }
         },
         "@types/js-cookie": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
-            "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA==",
-            "dev": true
-        },
-        "@types/lodash": {
-            "version": "4.14.183",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.183.tgz",
-            "integrity": "sha512-UXavyuxzXKMqJPEpFPri6Ku5F9af6ZJXUneHhvQJxavrEjuHkFp2YnDWHcxJiG7hk8ZkWqjcyNeW1s/smZv5cw==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+            "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
             "dev": true
         },
         "@types/node": {
@@ -1990,11 +1971,6 @@
             "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.3.tgz",
             "integrity": "sha512-iyT2MXws+dc2Wi6o3grCFtGXpeMvHmJqS27sMPGtV2eUu4PeFnG+33I8BlFK1t1NWMjOpcx9bridn5yxLDX2gQ==",
             "dev": true
-        },
-        "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.sortby": {
             "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,10 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "js-cookie": "^2.2.1",
-        "lodash": "^4.17.21"
+        "js-cookie": "^2.2.1"
     },
     "devDependencies": {
-        "@types/js-cookie": "^3.0.2",
-        "@types/lodash": "^4.14.183",
+        "@types/js-cookie": "^2.2.1",
         "@types/node": "^18.7.6",
         "tsup": "^6.2.2",
         "typescript": "^4.7.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ export default class DeviseTokenAuthClient {
     constructor(params: Partial<Config> | Array<Record<string, Partial<Config>>>) {
         // user is using multiple concurrent configs (>1 user types).
         if (params instanceof Array && params.length) {
-            throw new Error('DeviceTokenAuthClient config as an Array is not supported.\nWe need to migrate cloneDeep from lodash/fp/cloneDeepDeep first.');
+            throw new Error('DeviceTokenAuthClient config as an Array is not supported.\nWe need to migrate cloneDeep from lodash/fp/cloneDeep first.');
             // // extend each item in array from default settings
             // for (let i = 0; i < params.length; i++) {
             //     // get the name of the config

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import Cookies, { CookieAttributes } from 'js-cookie';
-import cloneDeep from 'lodash/fp/cloneDeep';
-import isObject from 'lodash/fp/isObject';
 
 type CustomOptions = {
     params?: Record<string, any>
@@ -179,6 +177,14 @@ function interpolate(str: string, ctx: Record<string, any>) {
     return str.replace(/{{\s?([a-zA-Z]+)\s?}}/g, (match, key) => ctx[key] || match);
 }
 
+/**
+ * Based on https://github.com/lodash/lodash/blob/2da024c3b4f9947a48517639de7560457cd4ec6c/isObject.js
+ */
+function isObject(value: unknown) {
+    const type = typeof value
+    return value != null && (type === 'object' || type === 'function')
+}
+
 const configs: Record<string, Config> = {
     default: {
         apiUrl: '/api',
@@ -279,33 +285,34 @@ export default class DeviseTokenAuthClient {
     constructor(params: Partial<Config> | Array<Record<string, Partial<Config>>>) {
         // user is using multiple concurrent configs (>1 user types).
         if (params instanceof Array && params.length) {
-            // extend each item in array from default settings
-            for (let i = 0; i < params.length; i++) {
-                // get the name of the config
-                const conf = params[i];
-                let label = '';
-                // eslint-disable-next-line no-restricted-syntax,guard-for-in
-                for (const k in conf) {
-                    label = k;
+            throw new Error('DeviceTokenAuthClient config as an Array is not supported.\nWe need to migrate cloneDeep from lodash/fp/cloneDeepDeep first.');
+            // // extend each item in array from default settings
+            // for (let i = 0; i < params.length; i++) {
+            //     // get the name of the config
+            //     const conf = params[i];
+            //     let label = '';
+            //     // eslint-disable-next-line no-restricted-syntax,guard-for-in
+            //     for (const k in conf) {
+            //         label = k;
 
-                    // set the first item in array as default config
-                    if (i === 0) {
-                        defaultConfigName = label;
-                    }
-                }
+            //         // set the first item in array as default config
+            //         if (i === 0) {
+            //             defaultConfigName = label;
+            //         }
+            //     }
 
-                // use copy preserve the original default settings object while
-                // extending each config object
-                const defaults = cloneDeep(configs.default);
-                const fullConfig = {} as any;
-                fullConfig[label] = Object.assign(defaults, conf[label]);
-                Object.assign(configs, fullConfig);
-            }
+            //     // use copy preserve the original default settings object while
+            //     // extending each config object
+            //     const defaults = cloneDeep(configs.default);
+            //     const fullConfig = {} as any;
+            //     fullConfig[label] = Object.assign(defaults, conf[label]);
+            //     Object.assign(configs, fullConfig);
+            // }
 
-            // remove existing default config
-            if (defaultConfigName !== 'default') {
-                delete configs.default;
-            }
+            // // remove existing default config
+            // if (defaultConfigName !== 'default') {
+            //     delete configs.default;
+            // }
         } else if (params instanceof Object) {
             // user is extending the single default config
             Object.assign(configs.default, params);
@@ -834,7 +841,7 @@ performBestTransit();`;
     /**
      * Generates query string based on simple or complex object graphs
      */
-    buildQueryString(params: Record<string, string>, prefix?: string) {
+    buildQueryString(params: Record<string, any>, prefix?: string) {
         const str: string[] = [];
         Object.entries(params).forEach(([key, val]) => {
             const k = prefix ? `${prefix}[${key}]` : key;


### PR DESCRIPTION
This drops Lodash as a dependency.

For now, we ditch the Array config support, and later on, when we migrate the `cloneDeep` function from Lodash we can support it again. Issue #4 will tackle this task.

The `isObject` function from Lodash was copy&pasted into the `src/index.ts` file.